### PR TITLE
Communication 수정, 버튼 컨트롤 이동

### DIFF
--- a/app/src/main/java/com/cbnu/josimair/Model/Communication.java
+++ b/app/src/main/java/com/cbnu/josimair/Model/Communication.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cbnu.josimair.Model;
 
 import android.app.Activity;
@@ -7,153 +23,444 @@ import android.bluetooth.BluetoothServerSocket;
 import android.bluetooth.BluetoothSocket;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
-import android.media.AudioManager;
-import android.os.AsyncTask;
-import android.os.Build;
+import android.os.Bundle;
 import android.os.Handler;
-import android.os.VibrationEffect;
-import android.os.Vibrator;
+import android.os.Message;
 import android.util.Log;
 
-import androidx.annotation.RequiresApi;
-import androidx.preference.PreferenceManager;
-
-import com.cbnu.josimair.Model.IndoorAir;
 import com.cbnu.josimair.R;
+import com.cbnu.josimair.ui.bluetooth.DeviceListActivity;
 
 import java.io.IOException;
-import java.util.Set;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.UUID;
 
 public class Communication {
 
-    private BluetoothAdapter btAdapter;
-    private Activity mActivity;
-    private Handler mHandler;
-    private BluetoothSocket btSocket;
-    private String mAddress;
-    private IndoorAir receivedAir;
-    private AsyncTask task;
-    private boolean isEnded;
-    private Vibrator vibrator;
+    private static final String TAG = "JosimAirBluetooth";
+    private static final String NAME_INSECURE = "JosimAirInsecure";
+    private static final UUID MY_UUID_INSECURE = UUID.fromString("8ce255c0-200a-11e0-ac64-0800200c9a66");
 
+    // Member fields
+    private Context mContext;
+    private BluetoothAdapter mAdapter;
+    private Handler mHandler;
+    private int mState;
+
+    private AcceptThread mAcceptThread;
+    private ConnectThread mConnectThread;
+    private ConnectedThread mConnectedThread;
+
+    // Constants that indicate the current connection state
+    public static final int STATE_NONE = 0;       // we're doing nothing
+    public static final int STATE_LISTEN = 1;     // now listening for incoming connections
+    public static final int STATE_CONNECTING = 2; // now initiating an outgoing connection
+    public static final int STATE_CONNECTED = 3;  // now connected to a remote device
+
+    // Constants that indicate the request and result code
     public final static int REQUEST_CODE_ENABLE = 2001;
     public final static int RESULT_CODE_BTLIST = 2002;
 
-    public interface ConnectedListener{
-        void onReceivedEvent();
-    }
-    private ConnectedListener mConnectedListener;
-
-    public void setConnectedCallback(ConnectedListener listener){
-        mConnectedListener = listener;
-    }
-
-    public interface ReceivedListener{
-        void onReceivedEvent();
-    }
-    private ReceivedListener mReceivedListener;
-    public void setReceivedCallback(ReceivedListener listener){
-        mReceivedListener = listener;
-    }
-
-    public Communication(Activity ac, Handler h){
-        mActivity = ac;
-        mHandler = h;
-        btAdapter = BluetoothAdapter.getDefaultAdapter();
-        vibrator = (Vibrator)mActivity.getSystemService(Context.VIBRATOR_SERVICE);
-        task = new AsyncTask() {
-            @Override
-            protected Object doInBackground(Object[] objects) {
-                return null;
-            }
-        };
+    /**
+     * 생성자. 새로운 Communication Session 준비
+     *
+     * @param context The UI Activity Context
+     * @param handler A Handler to send messages back to the UI Activity
+     */
+    public Communication(Context context, Handler handler){
+        mAdapter = BluetoothAdapter.getDefaultAdapter();
+        mContext = mContext;
+        mHandler = handler;
+        mState = STATE_NONE;
     }
 
     public boolean enable(){
-        if (btAdapter != null)
-            if(btAdapter.isEnabled())
+        if (mAdapter != null)
+            if(mAdapter.isEnabled())
                 return true;
         return false;
     }
 
     public void showDialog(){
-        if (btAdapter != null) {
-            if (!btAdapter.isEnabled()) {
+        if (mAdapter != null) {
+            if (!mAdapter.isEnabled()) {
                 Intent i = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
-                mActivity.startActivityForResult(i, REQUEST_CODE_ENABLE);
+                ((Activity) mContext).startActivityForResult(i, REQUEST_CODE_ENABLE);
             }
         }
     }
 
-    public void start(String address){
-        mAddress=address;
-        task.execute(new Runnable() {
-            @Override
-            public void run() {
-                BluetoothDevice device=btAdapter.getRemoteDevice(mAddress);
-                BluetoothSocket tmp=null;
-                try{
-                    tmp = device.createRfcommSocketToServiceRecord(UUID.randomUUID());
-                }catch(IOException e){
+    public void showDeviceList(){
+        ((Activity) mContext).startActivityForResult(new Intent(mContext, DeviceListActivity.class),Communication.RESULT_CODE_BTLIST);
+    }
 
+    /**
+     * Return the current connection state.
+     */
+    public synchronized int getState() {
+        return mState;
+    }
+
+    /**
+     * Bluetooth 연결을 위해 AcceptThread를 시작
+     */
+    public synchronized void start() {
+        Log.d(TAG, "start");
+
+        // Cancel any thread attempting to make a connection
+        if (mConnectThread != null) {
+            mConnectThread.cancel();
+            mConnectThread = null;
+        }
+
+        // Cancel any thread currently running a connection
+        if (mConnectedThread != null) {
+            mConnectedThread.cancel();
+            mConnectedThread = null;
+        }
+
+        // Start the thread to listen on a BluetoothServerSocket
+        if (mAcceptThread == null) {
+            mAcceptThread = new AcceptThread();
+            mAcceptThread.start();
+        }
+    }
+
+    /**
+     * remote device와 연결하기 위한 connectThread를 시작
+     *
+     * @param address 연결을 위한 BluetoothDevice Mac 주소
+     */
+    public synchronized void connect(String address) {
+        Log.d(TAG, "connect to: " + address);
+        BluetoothDevice device = mAdapter.getRemoteDevice(address);
+
+        // Cancel any thread attempting to make a connection
+        if (mState == STATE_CONNECTING) {
+            if (mConnectThread != null) {
+                mConnectThread.cancel();
+                mConnectThread = null;
+            }
+        }
+
+        // Cancel any thread currently running a connection
+        if (mConnectedThread != null) {
+            mConnectedThread.cancel();
+            mConnectedThread = null;
+        }
+
+        // Start the thread to connect with the given device
+        mConnectThread = new ConnectThread(device);
+        mConnectThread.start();
+    }
+
+    /**
+     * Bluetooth connection을 관리하기 위한 ConnectedThread를 시작함
+     *
+     * @param socket The BluetoothSocket on which the connection was made
+     * @param device The BluetoothDevice that has been connected
+     */
+    public synchronized void connected(BluetoothSocket socket, BluetoothDevice device) {
+        Log.d(TAG, "connected");
+
+        // Cancel the thread that completed the connection
+        if (mConnectThread != null) {
+            mConnectThread.cancel();
+            mConnectThread = null;
+        }
+
+        // Cancel any thread currently running a connection
+        if (mConnectedThread != null) {
+            mConnectedThread.cancel();
+            mConnectedThread = null;
+        }
+
+        if (mAcceptThread != null) {
+            mAcceptThread.cancel();
+            mAcceptThread = null;
+        }
+
+        mConnectedThread = new ConnectedThread(socket);
+        mConnectedThread.start();
+
+        // Send the name of the connected device back to the UI Activity
+        Message msg = mHandler.obtainMessage(Constants.MESSAGE_DEVICE_NAME);
+        Bundle bundle = new Bundle();
+        bundle.putString(Constants.DEVICE_NAME, device.getName());
+        msg.setData(bundle);
+        mHandler.sendMessage(msg);
+    }
+
+    /**
+     * Stop all threads
+     */
+    public synchronized void stop() {
+        Log.d(TAG, "stop");
+
+        if (mConnectThread != null) {
+            mConnectThread.cancel();
+            mConnectThread = null;
+        }
+
+        if (mConnectedThread != null) {
+            mConnectedThread.cancel();
+            mConnectedThread = null;
+        }
+
+        if (mAcceptThread != null) {
+            mAcceptThread.cancel();
+            mAcceptThread = null;
+        }
+
+        mState = STATE_NONE;
+    }
+
+    /**
+     * ConnectedThread를 이용해 OutputStream에 Write
+     *
+     * @param out The bytes to write
+     * @see ConnectedThread#write(byte[])
+     */
+    public void write(byte[] out) {
+        ConnectedThread r;
+        // Synchronize a copy of the ConnectedThread
+        synchronized (this) {
+            if (mState != STATE_CONNECTED) return;
+            r = mConnectedThread;
+        }
+        // unsynchronized
+        r.write(out);
+    }
+
+    /**
+     * connection이 실패했을 때 실행
+     */
+    private void connectionFailed() {
+        // 실패 메시지 전송
+        Message msg = mHandler.obtainMessage(Constants.MESSAGE_TOAST);
+        Bundle bundle = new Bundle();
+        bundle.putString(Constants.TOAST, mContext.getResources().getString(R.string.connection_failed));
+        msg.setData(bundle);
+        mHandler.sendMessage(msg);
+
+        mState = STATE_NONE;
+    }
+
+
+    /**
+     * Connection이 Lost 되었을 때 실행
+     */
+    private void connectionLost() {
+        Message msg = mHandler.obtainMessage(Constants.MESSAGE_TOAST);
+        Bundle bundle = new Bundle();
+        bundle.putString(Constants.TOAST, mContext.getResources().getString(R.string.connection_lost));
+        msg.setData(bundle);
+        mHandler.sendMessage(msg);
+
+        // update state
+        mState = STATE_NONE;
+    }
+
+    /**
+     * Thread는 Bluetooth의 서버 device로서 Client와
+     * Connection을 생성하기 위해 listen 함
+     */
+    private class AcceptThread extends Thread {
+        // The local server socket
+        private final BluetoothServerSocket mmServerSocket;
+
+        public AcceptThread() {
+            BluetoothServerSocket tmp = null;
+
+            try {
+                tmp = mAdapter.listenUsingInsecureRfcommWithServiceRecord(NAME_INSECURE, MY_UUID_INSECURE);
+            } catch (IOException e) {
+                Log.e(TAG, "Socket listen() failed", e);
+            }
+            mmServerSocket = tmp;
+            mState = STATE_LISTEN;
+        }
+
+        public void run() {
+            Log.d(TAG, "Socket BEGIN mAcceptThread" + this);
+            BluetoothSocket socket = null;
+
+            // Connectction이 이미 생성되어 있지 않으면
+            while (mState != STATE_CONNECTED) {
+                try {
+                    socket = mmServerSocket.accept();
+                } catch (IOException e) {
+                    Log.e(TAG, "Socket accept() failed", e);
+                    break;
                 }
-                btSocket=tmp;
 
-                //connected event occurred
-                mConnectedListener.onReceivedEvent();
-            }
-        });
-    }
-
-    public void start_Test_Using_RandomData() {
-        isEnded = false;
-        task.execute(new Runnable() {
-            @Override
-            public void run() {
-                long num = 0;
-                do {
-                    try {
-                        receivedAir = new IndoorAir((float) Math.random() * 50);
-                        //connected event occurred
-                        mReceivedListener.onReceivedEvent();
-
-                        if (num % 5 == 0) {
-                            AudioManager audioManager = (AudioManager) mActivity.getSystemService(Context.AUDIO_SERVICE);
-                            //vibrator.vibrate(VibrationEffect.createOneShot(1000,VibrationEffect.DEFAULT_AMPLITUDE));
-                            if (audioManager.getRingerMode() != AudioManager.RINGER_MODE_SILENT) {
-                                SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(mActivity);
-                                if (sp.getBoolean("진동", false)) {
-                                    if(Build.VERSION.SDK_INT>=26) {
-                                        vibrator.vibrate(VibrationEffect.createOneShot(1000,VibrationEffect.DEFAULT_AMPLITUDE));
-                                    }else {
-                                        vibrator.vibrate(1000);
-                                    }
+                // accepted
+                if (socket != null) {
+                    synchronized (Communication.this) {
+                        switch (mState) {
+                            case STATE_LISTEN:
+                            case STATE_CONNECTING:
+                                connected(socket, socket.getRemoteDevice());
+                                break;
+                            case STATE_NONE:
+                            case STATE_CONNECTED:
+                                // 이미 Connected 인 상태라면
+                                try {
+                                    // soket을 닫음
+                                    socket.close();
+                                } catch (IOException e) {
+                                    Log.e(TAG, "Could not close unwanted socket", e);
                                 }
-                            }
+                                break;
                         }
-                        num++;
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
                     }
-                }while(!isEnded);
+                }
             }
-        });
-    }
+            Log.i(TAG, "END mAcceptThread");
+        }
 
-    public void end(){
-        try {
-            task.cancel(true);
-            isEnded=true;
-        }catch(Exception e){
-            e.printStackTrace();
+        public void cancel() {
+            Log.d(TAG, "Socket cancel " + this);
+            try {
+                mmServerSocket.close();
+            } catch (IOException e) {
+                Log.e(TAG, "Socket close() of server failed", e);
+            }
         }
     }
 
-    public IndoorAir getReceivedAir(){
-        return this.receivedAir;
+    /**
+     * Server에 Connection을 생성하기 위한 Client Thread
+     */
+    private class ConnectThread extends Thread {
+        private final BluetoothSocket mmSocket;
+        private final BluetoothDevice mmDevice;
+
+        public ConnectThread(BluetoothDevice device) {
+            mmDevice = device;
+            BluetoothSocket tmp = null;
+
+            try {
+                tmp = device.createRfcommSocketToServiceRecord(MY_UUID_INSECURE);
+            } catch (IOException e) {
+                Log.e(TAG, "Socket create() failed", e);
+            }
+            mmSocket = tmp;
+            mState = STATE_CONNECTING;
+        }
+
+        public void run() {
+            Log.i(TAG, "BEGIN mConnectThread");
+
+            // Always cancel discovery because it will slow down a connection
+            mAdapter.cancelDiscovery();
+
+            // Connection 생성
+            try {
+                mmSocket.connect();
+            } catch (IOException e) {
+                // Close the socket
+                try {
+                    mmSocket.close();
+                } catch (IOException e2) {
+                    Log.e(TAG, "unable to close() socket during connection failure", e2);
+                }
+                connectionFailed();
+                return;
+            }
+
+            // 사용이 끝나면 Reset
+            synchronized (Communication.this) {
+                mConnectThread = null;
+            }
+
+            // connected thread 시작
+            connected(mmSocket, mmDevice);
+        }
+
+        public void cancel() {
+            try {
+                mmSocket.close();
+            } catch (IOException e) {
+                Log.e(TAG, "close() of connect socket failed", e);
+            }
+        }
+    }
+
+
+    /**
+     * Connection 되어있는 동안 run하는 Thread
+     * 모든 Socket 통신을 처리함
+     */
+    private class ConnectedThread extends Thread{
+        private final BluetoothSocket mmSocket;
+        private final InputStream mmInStream;
+        private final OutputStream mmOutStream;
+
+        public ConnectedThread(BluetoothSocket socket) {
+            Log.d(TAG, "create ConnectedThread");
+            mmSocket = socket;
+            InputStream tmpIn = null;
+            OutputStream tmpOut = null;
+
+            // 스트림 생성
+            try {
+                tmpIn = socket.getInputStream();
+                tmpOut = socket.getOutputStream();
+            } catch (IOException e) {
+                Log.e(TAG, "temp sockets not created", e);
+            }
+
+            mmInStream = tmpIn;
+            mmOutStream = tmpOut;
+            mState = STATE_CONNECTED;
+        }
+
+        public void run() {
+            Log.i(TAG, "BEGIN mConnectedThread");
+            byte[] buffer = new byte[1024];
+            int bytes;
+
+            // Connected 상태인 동안 InputStread을 계속 listen
+            while (mState == STATE_CONNECTED) {
+                try {
+                    // Read from the InputStream
+                    bytes = mmInStream.read(buffer);
+
+                    // Send the obtained bytes to the UI Activity
+                    mHandler.obtainMessage(Constants.MESSAGE_READ, bytes, -1, buffer).sendToTarget();
+                } catch (IOException e) {
+                    Log.e(TAG, "disconnected", e);
+                    connectionLost();
+                    break;
+                }
+            }
+        }
+
+        /**
+         * Outstream에 byte로 Write
+         *
+         * @param buffer The bytes to write
+         */
+        public void write(byte[] buffer) {
+            try {
+                mmOutStream.write(buffer);
+
+                // Share the sent message back to the UI Activity
+                //mHandler.obtainMessage(Constants.MESSAGE_WRITE, -1, -1, buffer).sendToTarget();
+            } catch (IOException e) {
+                Log.e(TAG, "Exception during write", e);
+            }
+        }
+
+        public void cancel() {
+            try {
+                mmSocket.close();
+            } catch (IOException e) {
+                Log.e(TAG, "close() of connect socket failed", e);
+            }
+        }
     }
 
 }

--- a/app/src/main/java/com/cbnu/josimair/Model/Constants.java
+++ b/app/src/main/java/com/cbnu/josimair/Model/Constants.java
@@ -1,0 +1,15 @@
+package com.cbnu.josimair.Model;
+
+public interface Constants {
+    // Communication Handler를 통해 생성되는 Message types
+    public static final int MESSAGE_STATE_CHANGE = 1;
+    public static final int MESSAGE_READ = 2;
+    public static final int MESSAGE_WRITE = 3;
+    public static final int MESSAGE_DEVICE_NAME = 4;
+    public static final int MESSAGE_TOAST = 5;
+
+    // Key names received from the BluetoothChatService Handler
+    public static final String DEVICE_NAME = "JosimAir";
+    public static final String TOAST = "toast";
+
+}

--- a/app/src/main/java/com/cbnu/josimair/ui/airInfo/AirInformationFragment.java
+++ b/app/src/main/java/com/cbnu/josimair/ui/airInfo/AirInformationFragment.java
@@ -13,13 +13,13 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProviders;
 
 import com.cbnu.josimair.Model.Communication;
+import com.cbnu.josimair.Model.IndoorAir;
 import com.cbnu.josimair.ui.MainActivity;
 import com.cbnu.josimair.R;
 
-public class AirInfomationFragment extends Fragment {
+public class AirInformationFragment extends Fragment {
 
     private AirInformationViewModel airInformationViewModel;
-    private Communication communication;
     private TextView airInfoTextView;
     private TextView airQualityTextView;
 
@@ -33,8 +33,6 @@ public class AirInfomationFragment extends Fragment {
         airInformationViewModel =
                 ViewModelProviders.of(this).get(AirInformationViewModel.class);
         View root = inflater.inflate(R.layout.fragment_airinformation, container, false);
-
-        communication = MainActivity.communication;
         airInfoTextView = (TextView) root.findViewById(R.id.airInfoTextView);
         airQualityTextView = (TextView) root.findViewById(R.id.airQualityTextView);
 
@@ -43,26 +41,21 @@ public class AirInfomationFragment extends Fragment {
         light_yellow = (ImageView) root.findViewById(R.id.yellow_light);
         light_red = (ImageView) root.findViewById(R.id.red_light);
 
-        setCallback();
+        MainActivity.fragment = this;
         return root;
     }
 
-    public void setCallback() {
-        communication.setReceivedCallback(new Communication.ReceivedListener() {
-            @Override
-            public void onReceivedEvent() {
-                Log.i("AirFragment","실내 공기정보 수신");
-                try {
-                    getActivity().runOnUiThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            airInformationViewModel.updateAirInfo(airInfoTextView, airQualityTextView, communication.getReceivedAir(), imageView_01, light_green, light_red, light_yellow);
-                        }
-                    });
-                } catch (Exception e) {
-                    e.printStackTrace();
+    public void update(final IndoorAir indoorAir){
+        try {
+            getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    airInformationViewModel.updateAirInfo(airInfoTextView, airQualityTextView, indoorAir, imageView_01, light_green, light_red, light_yellow);
                 }
-            }
-        });
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
+
 }

--- a/app/src/main/java/com/cbnu/josimair/ui/statistics/StatisticsFragment.java
+++ b/app/src/main/java/com/cbnu/josimair/ui/statistics/StatisticsFragment.java
@@ -30,7 +30,6 @@ import java.util.List;
 public class StatisticsFragment extends Fragment {
 
     private StatisticsViewModel statisticsViewModel;
-    private Communication communication;
     private AppDatabase db;
     private LineChart dayChart;
     private LineChart weekChart;
@@ -42,14 +41,6 @@ public class StatisticsFragment extends Fragment {
         View root = inflater.inflate(R.layout.fragment_statistics, container, false);
 
         db = MainActivity.db;
-        communication = MainActivity.communication;
-        communication.setReceivedCallback(new Communication.ReceivedListener() {
-            @Override
-            public void onReceivedEvent() {
-                Log.i("StatisticsFragment","실내 공기정보 수신");
-            }
-        });
-
         dayChart = (LineChart)root.findViewById(R.id.dayChart);
         setChartAttribute(dayChart);
         weekChart = (LineChart)root.findViewById(R.id.weekChart);
@@ -57,6 +48,9 @@ public class StatisticsFragment extends Fragment {
 
         drawDayChart();
         drawWeekChart();
+
+        MainActivity.fragment = this;
+
         return root;
     }
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -29,21 +29,10 @@
                 android:background="@color/menu_name"
                 />
 
-            <Button
-                android:id="@+id/btBtn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@drawable/home_bluetooth"
-                android:textColor="#0c6796"
-                android:layout_below="@id/airTitle"
-                android:layout_centerHorizontal="true"
-                android:text="@string/bluetooth_connect_btn" />
-
             <ImageView
                 android:id="@+id/air_face"
                 android:layout_width="150dp"
                 android:layout_height="150dp"
-                android:layout_below="@id/btBtn"
                 android:layout_centerHorizontal="true"
                 app:srcCompat="@drawable/smile" />
 

--- a/app/src/main/res/menu/menu.xml
+++ b/app/src/main/res/menu/menu.xml
@@ -15,4 +15,16 @@
         android:title="통계데이터추가"
         app:showAsAction="never"/>
 
+    <item android:id="@+id/action_btServer_btn"
+        android:title="BlueTooth 생성"
+        app:showAsAction="never"/>
+
+    <item android:id="@+id/action_btServer_Sign_btn"
+        android:title="BlueTooth 신호 보내기"
+        app:showAsAction="never"/>
+
+    <item android:id="@+id/action_btClient_btn"
+        android:title="BlueTooth 접속"
+        app:showAsAction="never"/>
+
 </menu>

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -19,7 +19,7 @@
 
     <fragment
         android:id="@+id/navigation_notifications"
-        android:name="com.cbnu.josimair.ui.airInfo.AirInfomationFragment"
+        android:name="com.cbnu.josimair.ui.airInfo.AirInformationFragment"
         android:label="@string/title_air"
         tools:layout="@layout/fragment_airinformation" />
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,13 +11,17 @@
     <string name="setting_sound">소리</string>
     <string name="menu_management">통계 관리</string>
 
+    <!-- Communication -->
+    <string name="connection_failed">접속에 실패했습니다</string>
+    <string name="connection_lost">블루투스 접속이 끊어졌습니다</string>
+
     <!--  BluetoothChat -->
     <string name="send">Send</string>
     <string name="not_connected">You are not connected to a device</string>
     <string name="bt_not_enabled_leaving">Bluetooth was not enabled. Leaving Bluetooth Chat.</string>
     <string name="title_connecting">connecting...</string>
     <string name="title_connected_to">connected: </string>
-    <string name="title_not_connected">not connected</string>
+
 
     <!--  DeviceListActivity -->
     <string name="scanning">scanning for devices...</string>
@@ -81,8 +85,7 @@
     <!-- Sync Preferences -->
     <string name="sync_title">Sync email periodically</string>
     <string name="attachment_title">Download incoming attachments</string>
-    <string name="attachment_summary_on">Automatically download attachments for incoming emails
-    </string>
+    <string name="attachment_summary_on">Automatically download attachments for incoming emails</string>
     <string name="attachment_summary_off">Only download attachments when manually requested</string>
 
 


### PR DESCRIPTION
기존
- event, callback 을 통해 ui 수정

수정
- 코드 가독성을 높이기 위해 handler를 통해 ui 수정
- state 추가 및 각 state 마다 별도의 thread 적용 및 코드 이동
- 테스트를 위한 Server side Bluetooth 기능 추가
- Home flagment의 Bluetooth 연결 버튼을 Action Bar로 이동

제거
- Handler를 통해 ui 업데이트가 일어나므로 각 Fragment에서
  ommunication 변수를 제거